### PR TITLE
manage in-line comments and non numeric values for params

### DIFF
--- a/gcodep.py
+++ b/gcodep.py
@@ -11,15 +11,29 @@ def parse_gcode(file_path):
         for line in file:
             line = line.strip()
             if line and not line.startswith(";"):  # Ignore comments
+                line = line.split(";")[0] # remove in-line comments
                 parts = line.split()
                 command = parts[0]
                 params = {}
                 for part in parts[1:]:
                     key = part[0]
-                    value = float(part[1:]) if "." in part else int(part[1:])
+                    value = try_read_value(part)
                     params[key] = value
                 commands.append(GCodeCommand(command, params))
     return commands
+
+def try_read_value(part): # not all G commands has values after X, Y, Z or E notation
+    if "." in part:
+        try:
+            return float(part[1:])
+        except:
+            return part[1:]
+    else:
+        try:
+            return int(part[1:])
+        except:
+            return part[1:]
+
 
 def analyze_gcode(commands):
     total_time = 0


### PR DESCRIPTION
now the code is able to parse g-code even if it has in-line comments (e.g.  "M220 S100 ;Reset Feedrate") and commands that have params not followed by numerical values (e.g. "M84 X Y E")